### PR TITLE
Fix/assa historic data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: composer-install composer-require composer-dump up down build shell shell-root nginx-reload migrate-status migrate-create migrate-run migrate-rollback seed-run collect recents reset stats logs db-shell db-backup cache-flush fix-regions distribution-build reprocess build-failure-report retry-failures help
+.PHONY: composer-install composer-require composer-dump up down build shell shell-root nginx-reload migrate-status migrate-create migrate-run migrate-rollback seed-run collect recents reset stats logs db-shell db-backup cache-flush fix-regions distribution-build reprocess reprocess-uuid build-failure-report retry-failures help
 .DEFAULT_GOAL := help
 
 # Set compose file based on ENV
@@ -81,6 +81,9 @@ distribution-build:
 reprocess:
 	PATHS='$(PATHS)' APPLY='$(APPLY)' $(DOCKER_COMPOSE) run --rm --user $(shell id -u):$(shell id -g) -e PATHS -e APPLY phpfpm php bin/reprocess.php
 
+reprocess-uuid:
+	UUID='$(UUID)' APPLY='$(APPLY)' $(DOCKER_COMPOSE) run --rm --user $(shell id -u):$(shell id -g) -e UUID -e APPLY phpfpm php bin/reprocess-uuid.php
+
 build-failure-report:
 	$(DOCKER_COMPOSE) run --rm --user $(shell id -u):$(shell id -g) phpfpm php bin/build-failure-report.php
 
@@ -155,6 +158,8 @@ help:
 	@echo "  distribution-build    - Build distribution aggregations from events"
 	@echo "  reprocess             - Reprocess events from stored sources (dry run by default)"
 	@echo "                          Optional: PATHS=\"HEK,HEK>>Flare\" APPLY=1"
+	@echo "  reprocess-uuid        - Reprocess specific event(s) by UUID (dry run by default)"
+	@echo "                          Usage: UUID=\"uuid1,uuid2\" APPLY=1"
 	@echo "  build-failure-report  - Rebuild aggregated failure report (powers /exceptions page)"
 	@echo "  retry-failures        - Retry stored failure JSONs through processors (dry run by default)"
 	@echo "                          Optional: TYPES=\"coordinate_errors\" SOURCES=\"name1,name2\" HASHES=\"sha,sha\" LIMIT=50 APPLY=1"

--- a/bin/reprocess-uuid.php
+++ b/bin/reprocess-uuid.php
@@ -1,0 +1,107 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Reprocess one (or more) events by UUID, replaying their stored
+ * sources/<uuid>.json through the current processor code.
+ *
+ * The event row is updated in place (its remote_id is unchanged because the
+ * source JSON is not modified), so the UUID is preserved. Distributions are not
+ * touched and the source JSON is not rewritten (it is the input).
+ *
+ * Usage (direct):   php bin/reprocess-uuid.php <uuid> [<uuid> ...]
+ * Usage (via make): make reprocess-uuid UUID="<uuid>,<uuid>"          # dry run
+ *                   make reprocess-uuid UUID="<uuid>" APPLY=1         # apply
+ */
+
+require __DIR__ . '/../src/bootstrap.php';
+
+use Helioviewer\EventsApi\Utils\Container;
+use Helioviewer\EventsApi\Events\Collector as EventCollector;
+
+// UUIDs from argv and/or the UUID env var (comma-separated).
+$uuids = array_slice($argv, 1);
+$envUuid = $_ENV['UUID'] ?? getenv('UUID') ?: '';
+if ($envUuid !== '') {
+    $uuids = array_merge($uuids, array_map('trim', explode(',', $envUuid)));
+}
+$uuids = array_values(array_filter(array_unique($uuids), fn($u) => $u !== ''));
+
+if (empty($uuids)) {
+    fwrite(STDERR, "Usage: reprocess-uuid.php <uuid> [<uuid> ...]  (or UUID=\"a,b\")\n");
+    exit(1);
+}
+
+$applyRaw = $_ENV['APPLY'] ?? getenv('APPLY') ?: '';
+$apply = $applyRaw !== '' && $applyRaw !== '0' && strcasecmp($applyRaw, 'false') !== 0;
+
+$container = Container::getInstance();
+$eventRepository = $container['eventRepository'];
+$jsonStorage = $container['jsonStorage'];
+$logger = $container['logger'];
+
+$collector = EventCollector::createStandard(
+    $eventRepository,
+    $container['regionRepository'],
+    $container['distributionRepository'],
+    $jsonStorage,
+    $container['failureStorage'],
+    $container['httpClient'],
+    $container['harp'],
+    $container['noaa'],
+    $logger
+);
+
+$sources = $collector->getSources();
+
+/** Longest registered source prefix matching this path, with its source. */
+function matchSource(string $path, array $sources): array
+{
+    $bestPrefix = '';
+    $bestSource = null;
+    foreach ($sources as $prefix => $source) {
+        if (($path === $prefix || str_starts_with($path, $prefix . '>>'))
+            && strlen($prefix) > strlen($bestPrefix)) {
+            $bestPrefix = $prefix;
+            $bestSource = $source;
+        }
+    }
+    return [$bestPrefix, $bestSource];
+}
+
+$mode = $apply ? 'APPLY' : 'DRY RUN';
+$logger->info("reprocess-uuid [{$mode}] - " . count($uuids) . " uuid(s)");
+
+foreach ($uuids as $uuid) {
+    $event = $eventRepository->findById($uuid);
+    if (!$event) {
+        $logger->warning("Not found: {$uuid}");
+        continue;
+    }
+
+    $raw = $jsonStorage->loadById($uuid, 'sources');
+    if (!$raw) {
+        $logger->warning("No sources/<uuid>.json: {$uuid} ({$event->path})");
+        continue;
+    }
+
+    [$prefix, $source] = matchSource($event->path, $sources);
+    if (!$source) {
+        $logger->warning("No source for path: {$event->path} ({$uuid})");
+        continue;
+    }
+
+    if (!$apply) {
+        $logger->info("DRY RUN would reprocess: {$uuid} | {$event->path} | prefix={$prefix}");
+        continue;
+    }
+
+    $saved = $collector->processRawRecord($raw, $source, $prefix, true);
+    if ($saved === null) {
+        $logger->warning("No processor matched: {$uuid} ({$event->path})");
+    } else {
+        $logger->info("Reprocessed: {$uuid} | {$event->path}");
+    }
+}

--- a/bin/reprocess.php
+++ b/bin/reprocess.php
@@ -75,7 +75,14 @@ if (!$apply) {
 }
 
 $pageSize = 1000;
-$totalEvents = $eventRepository->count();
+// When a path filter is given, page over only the matching events (SQL-filtered)
+// instead of scanning the whole table. Same set is reprocessed — the in-loop
+// eventMatchesFilter() check below still applies. Unfiltered runs (no PATHS) keep
+// the original full-table scan.
+$filtered = !empty($pathPrefixes);
+$totalEvents = $filtered
+    ? $eventRepository->countByPathPrefixes($pathPrefixes)
+    : $eventRepository->count();
 $totalPages = (int) ceil($totalEvents / $pageSize);
 $logger->info("Scanning {$totalEvents} events in {$totalPages} pages of {$pageSize}");
 
@@ -89,7 +96,9 @@ $startTime = microtime(true);
 
 try {
     for ($page = 0; $page < $totalPages; $page++) {
-        $events = $eventRepository->getWithPage($page, $pageSize);
+        $events = $filtered
+            ? $eventRepository->getByPathPrefixesWithPage($pathPrefixes, $page, $pageSize)
+            : $eventRepository->getWithPage($page, $pageSize);
 
 
 

--- a/src/Api/Controllers/Controller.php
+++ b/src/Api/Controllers/Controller.php
@@ -15,6 +15,7 @@ use Psr\SimpleCache\CacheInterface;
 use Psr\Http\Client\ClientInterface;
 use Helioviewer\EventsApi\Coordinator\CoordinateRotator;
 use Helioviewer\EventsApi\Events\Event;
+use Helioviewer\EventsApi\Events\Sources\JsonSource;
 use Helioviewer\EventsApi\Sentry\ClientInterface as SentryClientInterface;
 
 /**
@@ -97,38 +98,83 @@ abstract class Controller
     }
 
     /**
-     * Helper method to enhance event with additional data
+     * Enhance an event with sidecar JSONs, legacy aliases, computed
+     * legacy_id, and API URL helpers. Accepts either an Event model or a
+     * plain array (matches what the repositories return for batch reads).
+     *
+     * Per-event shape mirrors `Legacy::normalizeEvent` (used by the
+     * `/helioviewer/events/...` endpoints) so consumers get a consistent
+     * record across both APIs. Additively keeps the legacy `url` and
+     * `source_url` helpers from the v1 contract.
      */
-    protected function enhanceEvent(Event $event): array
+    protected function enhanceEvent(Event|array $event): array
     {
-        $eventArray = $event->toArray();
-        $uuid = $event->id;
+        $eventArray = is_array($event) ? $event : $event->toArray();
+        $uuid       = $eventArray['id'] ?? null;
 
-        // Format timestamps
+        // Format timestamps (existing v1 contract: space-separated)
         foreach (['start', 'end', 'peak', 'coordinate_time'] as $field) {
-            if (!empty($eventArray[$field])) {
-                $eventArray[$field] = $this->formatTimestamp($eventArray[$field]);
+            if (!empty($eventArray[$field]) && is_numeric($eventArray[$field])) {
+                $eventArray[$field] = $this->formatTimestamp((int) $eventArray[$field]);
             }
         }
 
-        // Add source, views, and links from JSON storage
-        $eventArray['source'] = $this->jsonStorage->load("/u/apps/data/sources/{$uuid}.json") ?: null;
-        $eventArray['views'] = $this->jsonStorage->load("/u/apps/data/views/{$uuid}.json") ?: [];
-        $eventArray['link'] = $this->jsonStorage->load("/u/apps/data/links/{$uuid}.json");
+        // Legacy aliases (parity with Helioviewer endpoint shape)
+        $eventArray['type']       = $eventArray['legacy_type']    ?? null;
+        $eventArray['event_type'] = $eventArray['legacy_type']    ?? null;
+        $eventArray['version']    = $eventArray['legacy_version'] ?? null;
+        $eventArray['pin']        = $eventArray['legacy_pin']     ?? null;
 
-        // Add API URLs - replace id with url, source with source_url
-        $apiUrl = rtrim($_ENV['APIURL'] ?? 'https://events.helioviewer.org/', '/');
-        $reorderedArray = [];
-        foreach ($eventArray as $key => $value) {
-            if ($key === 'id') {
-                $reorderedArray['url'] = "{$apiUrl}/api/v1/events/{$uuid}";
-            } elseif ($key === 'source') {
-                $reorderedArray['source_url'] = "{$apiUrl}/api/v1/events/{$uuid}/source";
+        // Sidecar JSONs (source/views/link)
+        if ($uuid !== null) {
+            $sourceData = $this->jsonStorage->load("/u/apps/data/sources/{$uuid}.json");
+            $eventArray['source'] = $sourceData ?: null;
+
+            $viewsData = $this->jsonStorage->load("/u/apps/data/views/{$uuid}.json");
+            $eventArray['views'] = $viewsData ?: [];
+
+            $linksData = $this->jsonStorage->load("/u/apps/data/links/{$uuid}.json");
+            if (empty($linksData)) {
+                $linksData = [
+                    'url'  => Event::getUrlById($uuid),
+                    'text' => 'Helioviewer Event URL',
+                ];
+            }
+            $eventArray['link'] = $linksData;
+
+            if (($eventArray['source_id'] ?? null) === JsonSource::HEK) {
+                $eventArray['concept'] = $eventArray['source']['concept'] ?? null;
+            }
+        }
+
+        // legacy_id per source (mirrors Legacy::normalizeEvent)
+        if (isset($eventArray['path'])) {
+            $path      = $eventArray['path'];
+            $pathParts = explode('>>', $path);
+            $source    = $eventArray['source'] ?? [];
+
+            if ($path === 'CCMC>>DONKI>>CME') {
+                $eventArray['legacy_id'] = $source['activityID'] ?? $eventArray['id'];
+            } elseif ($path === 'CCMC>>DONKI>>Solar Flares') {
+                $eventArray['legacy_id'] = $source['flrID'] ?? $eventArray['id'];
+            } elseif (str_starts_with($path, 'CCMC>>Solar Flare Predictions>>') && count($pathParts) === 3) {
+                $eventArray['legacy_id'] = hash('sha256', json_encode($source));
+            } elseif (str_starts_with($path, 'RHESSI>>Solar Flares>>Flare') && count($pathParts) === 3) {
+                $eventArray['legacy_id'] = $source['id'] ?? $eventArray['id'];
+            } elseif (str_starts_with($path, 'HEK>>')) {
+                $eventArray['legacy_id'] = $source['kb_archivid'] ?? $eventArray['id'];
             } else {
-                $reorderedArray[$key] = $value;
+                $eventArray['legacy_id'] = $eventArray['id'];
             }
         }
 
-        return $reorderedArray;
+        // v1 contract: include API URL helpers alongside id/source (additive)
+        if ($uuid !== null) {
+            $apiUrl = rtrim($_ENV['APIURL'] ?? 'https://events.helioviewer.org/', '/');
+            $eventArray['url']        = "{$apiUrl}/api/v1/events/{$uuid}";
+            $eventArray['source_url'] = "{$apiUrl}/api/v1/events/{$uuid}/source";
+        }
+
+        return $eventArray;
     }
 }

--- a/src/Api/Controllers/EventController.php
+++ b/src/Api/Controllers/EventController.php
@@ -16,52 +16,7 @@ class EventController extends Controller
     {
         try {
             $events = $this->eventRepository->getRecent(100);
-
-            // Enhance events with source, views, links, and regions data
-            $enhancedEvents = array_map(function ($event) {
-                // Convert Event object to array (includes regions from eager loading)
-                $eventArray = is_array($event) ? $event : $event->toArray();
-                $uuid = $eventArray['id'];
-
-                // Format timestamps (replace raw values)
-                foreach (['start', 'end', 'peak', 'coordinate_time'] as $field) {
-                    if (!empty($eventArray[$field])) {
-                        $eventArray[$field] = $this->formatTimestamp($eventArray[$field]);
-                    }
-                }
-                // created_at and updated_at are already formatted by Eloquent
-
-                // Load source JSON data
-                $sourceData = $this->jsonStorage->load("/u/apps/data/sources/{$uuid}.json");
-                $eventArray['source'] = $sourceData ?: null;
-
-                // Load views JSON data
-                $viewsData = $this->jsonStorage->load("/u/apps/data/views/{$uuid}.json");
-                $eventArray['views'] = $viewsData ?: [];
-
-                // Load links JSON data
-                $linksData = $this->jsonStorage->load("/u/apps/data/links/{$uuid}.json");
-                // Links can be either an array or object, preserve what's loaded
-                $eventArray['link'] = $linksData;
-
-                // Add API links - replace id with url, replace source with source_url
-                $apiUrl = rtrim($_ENV['APIURL'] ?? 'https://events.helioviewer.org/', '/');
-
-                // Replace id with url and source with source_url
-                $reorderedArray = [];
-                foreach ($eventArray as $key => $value) {
-                    if ($key === 'id') {
-                        $reorderedArray['url'] = "{$apiUrl}/api/v1/events/{$uuid}";
-                    } elseif ($key === 'source') {
-                        $reorderedArray['source_url'] = "{$apiUrl}/api/v1/events/{$uuid}/source";
-                    } else {
-                        $reorderedArray[$key] = $value;
-                    }
-                }
-
-                return $reorderedArray;
-            }, $events);
-
+            $enhancedEvents = array_map(fn($e) => $this->enhanceEvent($e), $events);
             return $this->json($response, $enhancedEvents);
 
         } catch (\Exception $e) {

--- a/src/Api/Controllers/RegionController.php
+++ b/src/Api/Controllers/RegionController.php
@@ -87,47 +87,8 @@ class RegionController extends Controller
                 ->limit(2000)
                 ->get();
 
-            // Format events
-            $enhancedEvents = $events->map(function ($event) {
-                $eventArray = (array)$event;
-                $uuid = $eventArray['id'];
-
-                // Format timestamps
-                foreach (['start', 'end', 'peak', 'coordinate_time'] as $field) {
-                    if (!empty($eventArray[$field])) {
-                        $eventArray[$field] = $this->formatTimestamp($eventArray[$field]);
-                    }
-                }
-
-                // Load source JSON data
-                $sourceData = $this->jsonStorage->load("/u/apps/data/sources/{$uuid}.json");
-                $eventArray['source'] = $sourceData ?: null;
-
-                // Load views JSON data
-                $viewsData = $this->jsonStorage->load("/u/apps/data/views/{$uuid}.json");
-                $eventArray['views'] = $viewsData ?: [];
-
-                // Load links JSON data
-                $linksData = $this->jsonStorage->load("/u/apps/data/links/{$uuid}.json");
-                $eventArray['link'] = $linksData;
-
-                // Add API links
-                $apiUrl = rtrim($_ENV['APIURL'] ?? 'https://events.helioviewer.org/', '/');
-
-                // Replace id with url and source with source_url
-                $reorderedArray = [];
-                foreach ($eventArray as $key => $value) {
-                    if ($key === 'id') {
-                        $reorderedArray['url'] = "{$apiUrl}/api/v1/events/{$uuid}";
-                    } elseif ($key === 'source') {
-                        $reorderedArray['source_url'] = "{$apiUrl}/api/v1/events/{$uuid}/source";
-                    } else {
-                        $reorderedArray[$key] = $value;
-                    }
-                }
-
-                return $reorderedArray;
-            })->toArray();
+            // Format events (mirrors EventController shape; events come back as stdClass from the JOIN query)
+            $enhancedEvents = $events->map(fn($event) => $this->enhanceEvent((array) $event))->toArray();
 
             $result = [
                 'region' => [

--- a/src/Events/Processors/CCMC/FlareScoreboard/AssaProcessor.php
+++ b/src/Events/Processors/CCMC/FlareScoreboard/AssaProcessor.php
@@ -40,12 +40,21 @@ class AssaProcessor extends Processor
      */
     protected function readCoordinates(array $rawRecord): ?array
     {
+        // CCMC bug: upstream sends -1 as the default value for a missing NOAA
+        // response (LocationTime and both coordinates all -1). Skip NOAA in that
+        // case and fall through to Catania/Model.
+        $invalidNoaaResponseDueMinusOneDefaultValueCCMCbug =
+            ($rawRecord['NOAALocationTime'] ?? null) == -1
+            && ($rawRecord['NOAALatitude'] ?? null) == -1
+            && ($rawRecord['NOAALongitude'] ?? null) == -1;
+
         // ASSA-specific: Try NOAA first, but don't require NOAARegionId
-        if (isset($rawRecord['NOAALatitude']) && 
+        if (!$invalidNoaaResponseDueMinusOneDefaultValueCCMCbug &&
+            isset($rawRecord['NOAALatitude']) &&
             isset($rawRecord['NOAALongitude']) &&
             $rawRecord['NOAALatitude'] !== '' &&
             $rawRecord['NOAALongitude'] !== '') {
-            
+
             // Handle 0 values correctly - use isset instead of !empty
             $regionId = (isset($rawRecord['NOAARegionId']) && $rawRecord['NOAARegionId'] !== '') ? $rawRecord['NOAARegionId'] : 'Unknown';
             $this->logger->info("ASSA: Using NOAA coordinates for region {$regionId}");
@@ -76,42 +85,10 @@ class AssaProcessor extends Processor
         return null;
     }
     
-    /**
-     * Collect all region information from raw record for ASSA
-     * 
-     * @param array $rawRecord The raw event data
-     * @return array Array of region info arrays
-     */
-    protected function collectRegions(array $rawRecord): array
-    {
-        // First get all regions from parent implementation
-        $regions = parent::collectRegions($rawRecord);
-        
-        // Use array_filter to check if NOAA region exists
-        $noaaRegions = array_filter($regions, function($region) {
-            return $region['organization'] === 'NOAA';
-        });
-        
-        // If NOAA region already exists, return as-is
-        if (!empty($noaaRegions)) {
-            return $regions;
-        }
-        
-        // No NOAA region found - check if NOAA coordinates exist
-        if (isset($rawRecord['NOAALatitude']) && 
-            isset($rawRecord['NOAALongitude']) &&
-            $rawRecord['NOAALatitude'] !== '' &&
-            $rawRecord['NOAALongitude'] !== '') {
-            
-            // Add NOAA with 'UNK' id
-            $regions[] = [
-                'organization' => 'NOAA',
-                'external_id' => 'UNK'
-            ];
-            
-            $this->logger->debug("ASSA: Added NOAA region with ID: UNK (coordinates exist but no RegionId)");
-        }
-        
-        return $regions;
-    }
+    // collectRegions() is intentionally NOT overridden: ASSA links NOAA/Catania/
+    // Model regions only when their RegionId is present (the base behavior). We
+    // no longer attach a placeholder NOAA:UNK region for records that carry NOAA
+    // coordinates but no NOAARegionId — coordinates still come from those values
+    // in readCoordinates(), but the event is not grouped under a NOAA region it
+    // doesn't actually have.
 }

--- a/src/Events/Repositories/Postgres.php
+++ b/src/Events/Repositories/Postgres.php
@@ -523,6 +523,56 @@ class Postgres implements RepositoryInterface
     }
 
     /**
+     * Page over events matching any of the given path prefixes, ordered by
+     * start time — same semantics as getWithPage() but path-restricted.
+     *
+     * @param array<string> $pathPrefixes
+     * @return array<Event>
+     */
+    public function getByPathPrefixesWithPage(array $pathPrefixes, int $page, int $pageSize): array
+    {
+        $pathPrefixes = array_values(array_filter($pathPrefixes, fn($p) => $p !== ''));
+        if (empty($pathPrefixes)) {
+            return [];
+        }
+
+        $offset = $page * $pageSize;
+
+        return Event::where(function (Builder $query) use ($pathPrefixes) {
+                foreach ($pathPrefixes as $prefix) {
+                    $query->orWhere('path', '=', $prefix);
+                    $query->orWhere('path', 'LIKE', $prefix . '>>%');
+                }
+            })
+            ->orderBy('start')
+            ->offset($offset)
+            ->limit($pageSize)
+            ->get()
+            ->all();
+    }
+
+    /**
+     * Count events matching any of the given path prefixes
+     * (path = prefix OR path LIKE 'prefix>>%').
+     *
+     * @param array<string> $pathPrefixes
+     */
+    public function countByPathPrefixes(array $pathPrefixes): int
+    {
+        $pathPrefixes = array_values(array_filter($pathPrefixes, fn($p) => $p !== ''));
+        if (empty($pathPrefixes)) {
+            return 0;
+        }
+
+        return Event::where(function (Builder $query) use ($pathPrefixes) {
+            foreach ($pathPrefixes as $prefix) {
+                $query->orWhere('path', '=', $prefix);
+                $query->orWhere('path', 'LIKE', $prefix . '>>%');
+            }
+        })->count();
+    }
+
+    /**
      * Find events matching any of the given path prefixes that overlap with time range.
      *
      * An event overlaps with [start, end] if: event.start < end AND event.end > start

--- a/src/Events/Repositories/RepositoryInterface.php
+++ b/src/Events/Repositories/RepositoryInterface.php
@@ -168,6 +168,32 @@ interface RepositoryInterface
     public function getWithPage(int $page, int $pageSize): array;
 
     /**
+     * Retrieve a page of events whose path matches any of the given prefixes,
+     * ordered by start time (oldest first). Same ordering/semantics as
+     * {@see getWithPage()} but restricted to matching paths so batch jobs can
+     * walk only the relevant subset instead of the whole table.
+     *
+     * A path matches a prefix when `path = prefix` OR `path LIKE 'prefix>>%'`.
+     *
+     * @param array<string> $pathPrefixes Path-prefix selectors (e.g. "HEK", "HEK>>Flare")
+     * @param int           $page         Page number (0-indexed)
+     * @param int           $pageSize     Number of events per page
+     *
+     * @return array<Event>
+     */
+    public function getByPathPrefixesWithPage(array $pathPrefixes, int $page, int $pageSize): array;
+
+    /**
+     * Count events whose path matches any of the given prefixes
+     * (`path = prefix` OR `path LIKE 'prefix>>%'`).
+     *
+     * @param array<string> $pathPrefixes Path-prefix selectors
+     *
+     * @return int Number of matching events
+     */
+    public function countByPathPrefixes(array $pathPrefixes): int;
+
+    /**
      * Find an event by its remote ID.
      *
      * @param string $remoteId The unique identifier from the source system


### PR DESCRIPTION
**Fix ASSA missing-coordinate (`-1`) bug + reprocess-by-UUID tooling**

CCMC emitted `-1` for missing NOAA coordinates in ASSA predictions for ~2 months, which our permissive parser accepted as a real `(-1,-1)` location (plotting events wrong and attaching placeholder `NOAA:UNK` regions); this fixes the ASSA parser and drops the `NOAA:UNK` placeholder so NOAA is linked only with a real RegionId.
Adds `bin/reprocess-uuid.php` + `make reprocess-uuid` to repair existing rows in place — the fix is parser-side so source JSON is untouched, `remote_id` is stable, and **UUIDs are preserved**.
Post-deploy: `DELETE FROM regions WHERE organization='NOAA' AND external_id='UNK';` then `make reprocess PATHS="CCMC>>Solar Flare Predictions>>ASSA" APPLY=1`.